### PR TITLE
#13 Change role name to avoid dashes ('-')

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     docker:
       - image: circleci/python:2.7.15-stretch
-    working_directory: ~/jira-role
+    working_directory: ~/jira_role
 
     steps:
       - checkout

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 
 Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
- including treating everyone with respect: https://github.com/idealista/jira-role/blob/master/.github/CODE_OF_CONDUCT.md
+ including treating everyone with respect: https://github.com/idealista/jira_role/blob/master/.github/CODE_OF_CONDUCT.md
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
-## [Unreleased](https://github.com/idealista/jira-role/tree/develop)
+## [Unreleased](https://github.com/idealista/jira_role/tree/develop)
 
 ### Changed
-- *[#11](https://github.com/idealista/jira-role/issues/11) Molecule v2 upgrade* @jperera
+- *[#11](https://github.com/idealista/jira_role/issues/11) Molecule v2 upgrade* @jperera
 
 ### Fixed
-- *[#5](https://github.com/idealista/jira-role/issues/5) Using new Idealista's Java Role version to avoid 404 Java installation issue* @jperera
+- *[#5](https://github.com/idealista/jira_role/issues/5) Using new Idealista's Java Role version to avoid 404 Java installation issue* @jperera
 
-## [1.0.2](https://github.com/idealista/jira-role/tree/1.0.2)
-[Full Changelog](https://github.com/idealista/jira-role/compare/1.0.1...1.0.2)
+## [1.0.2](https://github.com/idealista/jira_role/tree/1.0.2)
+[Full Changelog](https://github.com/idealista/jira_role/compare/1.0.1...1.0.2)
 ### Added
 - *Added CircleCI integration* @jnogol
 
@@ -22,10 +22,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Fixed
 - *Using new Idealista's Java Role version to avoid 404 Java installation issue* @jnogol
 
-## [1.0.1](https://github.com/idealista/jira-role/tree/1.0.1)
-[Full Changelog](https://github.com/idealista/jira-role/compare/1.0.0...1.0.1)
+## [1.0.1](https://github.com/idealista/jira_role/tree/1.0.1)
+[Full Changelog](https://github.com/idealista/jira_role/compare/1.0.0...1.0.1)
 ### Fixed
 - *Using new Idealista's Java Role version to avoid 404 Java installation issue* @jnogol
 
-## [1.0.0](https://github.com/idealista/jira-role/tree/1.0.0)
+## [1.0.0](https://github.com/idealista/jira_role/tree/1.0.0)
 - *First version*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Logo](https://raw.githubusercontent.com/idealista/jira-role/master/logo.gif)
+![Logo](https://raw.githubusercontent.com/idealista/jira_role/master/logo.gif)
 
-[![Build Status](https://travis-ci.org/idealista/jira-role.png)](https://travis-ci.org/idealista/jira-role)
+[![Build Status](https://travis-ci.org/idealista/jira_role.png)](https://travis-ci.org/idealista/jira_role)
 
 # Jira Ansible role
 
@@ -33,7 +33,7 @@ For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Docker]
 Create or add to your roles dependency file (e.g requirements.yml):
 
 ``` yml
-- src: idealista.jira-role
+- src: idealista.jira_role
   version: 1.0.0
   name: jira
 ```
@@ -70,7 +70,7 @@ $ pipenv run molecule test
 
 ## Versioning
 
-For the versions available, see the [tags on this repository](https://github.com/idealista/jira-role/tags).
+For the versions available, see the [tags on this repository](https://github.com/idealista/jira_role/tags).
 
 Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGELOG.md) file.
 
@@ -78,7 +78,7 @@ Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGE
 
 * **Idealista** - *Work with* - [idealista](https://github.com/idealista)
 
-See also the list of [contributors](https://github.com/idealista/jira-role/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/idealista/jira_role/contributors) who participated in this project.
 
 ## License
 

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,5 +2,5 @@
 - name: Converge
   hosts: all
   roles:
-    - role: java-role
-    - role: jira-role
+    - role: java_role
+    - role: jira_role

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: idealista.java_role
   version: 3.3.0
-  name: java-role
+  name: java_role


### PR DESCRIPTION
Role names has to follow Official Ansible Guide to role names: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names

Role names are limited to lowercase word characters (i.e., a-z, 0-9) and ‘’. No special characters are allowed, including ‘.’, ‘-‘, and space. During import, any ‘.’ and ‘-‘ characters contained in the repository name or role_name will be replaced with ‘’.
#13 
