### PR TITLE
Added recommended setting validation_query_timeout to dbconfig.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/jira_role/tree/develop)
+- [#20](https://github.com/idealista/jira_role/issues/20) *Added recommended setting validation_query_timeout to dbconfig.xml* @mmolinac
 
 ## [1.1.0](https://github.com/idealista/jira_role/tree/1.1.0)
 [Full Changelog](https://github.com/idealista/jira_role/compare/1.0.2...1.1.0)

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: idealista.java_role
-  version: 3.3.0
+  version: 3.4.2
   name: java_role

--- a/templates/conf/dbconfig.xml.j2
+++ b/templates/conf/dbconfig.xml.j2
@@ -13,6 +13,7 @@
     <pool-max-size>20</pool-max-size>
     <pool-max-wait>30000</pool-max-wait>
     <validation-query>{{ jira_database_validation_query }}</validation-query>
+    <validation-query-timeout>{{ jira_database_validation_query_timeout }}</validation-query-timeout>
     <min-evictable-idle-time-millis>60000</min-evictable-idle-time-millis>
     <time-between-eviction-runs-millis>300000</time-between-eviction-runs-millis>
     <pool-max-idle>20</pool-max-idle>

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,4 @@
 ---
 - src: idealista.java-role
-  version: 3.3.0
+  version: 3.4.2
   name: java

--- a/vars/mysql-vars.yml
+++ b/vars/mysql-vars.yml
@@ -4,3 +4,4 @@ jira_mysql_repo: "deb {{ jira_mysql_repo_url }} {{ ansible_distribution_release 
 jira_database_url: "jdbc:mysql://{{ jira_database_host }}:{{ jira_database_port }}/{{ jira_database_name }}?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=default_storage_engine=InnoDB"
 jira_database_driver_class: 'com.mysql.jdbc.Driver'
 jira_database_validation_query: 'select 1'
+jira_database_validation_query_timeout: 3

--- a/vars/oracle-vars.yml
+++ b/vars/oracle-vars.yml
@@ -2,3 +2,4 @@
 jira_database_url: "jdbc:oracle:thin:@(DESCRIPTION = (ADDRESS_LIST = (ADDRESS = (PROTOCOL = TCP)(HOST = {{ jira_database_host }})(PORT = {{ jira_database_port }})))(CONNECT_DATA = (SERVICE_NAME = {{ jira_database_service_name }})(SERVER = DEDICATED)))"
 jira_database_driver_class: 'oracle.jdbc.OracleDriver'
 jira_database_validation_query: 'select 1 from dual'
+jira_database_validation_query_timeout: 3

--- a/vars/oracle10g-vars.yml
+++ b/vars/oracle10g-vars.yml
@@ -2,3 +2,4 @@
 jira_database_url: "jdbc:oracle:thin:@(DESCRIPTION = (ADDRESS_LIST = (ADDRESS = (PROTOCOL = TCP)(HOST = {{ jira_database_host }})(PORT = {{ jira_database_port }})))(CONNECT_DATA = (SERVICE_NAME = {{ jira_database_service_name }})(SERVER = DEDICATED)))"
 jira_database_driver_class: 'oracle.jdbc.OracleDriver'
 jira_database_validation_query: 'select 1 from dual'
+jira_database_validation_query_timeout: 3


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
At JIRA startup, you may receive a message about configuring `validation_query_timeout` in `dbconfig.xml` as a recommendation.
I've setup recommended values for MySQL and the same default values for Oracle and MSSQL, although they only recommend a default value for MySQL.

### Benefits

Follow Atlassian direction about MySQL configuration.

### Possible Drawbacks

None that I know of.

### Applicable Issues

Fixes https://github.com/idealista/jira_role/issues/20
