### PR TITLE
[TASK] OPS-445: Have Jira run in versioned install directories

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,7 +2,7 @@
 - name: JIRA | Template Jira environment configuration
   template:
     src: "{{ jira_setenv_template_path }}"
-    dest: "{{ jira_installation_dir }}/bin/setenv.sh"
+    dest: "{{ jira_installation_dir }}/{{ jira_package_dir }}/bin/setenv.sh"
     backup: yes
     mode: 0755
     owner: "{{ jira_user }}"
@@ -12,7 +12,7 @@
 - name: JIRA | Template server configuration
   template:
     src: "{{ jira_server_conf_template_path }}"
-    dest: "{{ jira_installation_dir }}/conf/server.xml"
+    dest: "{{ jira_installation_dir }}/{{ jira_package_dir }}/conf/server.xml"
     backup: yes
     mode: 0755
     owner: "{{ jira_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,6 @@
     src: "{{ jira_download_dir }}/{{ jira_package }}"
     dest: "{{ jira_installation_dir }}"
     remote_src: yes
-    extra_opts: --strip-components=1
     owner: "{{ jira_user }}"
     group: "{{ jira_group }}"
     mode: 0755

--- a/templates/systemd/jira.service.j2
+++ b/templates/systemd/jira.service.j2
@@ -5,10 +5,10 @@ After=network.target
 [Service]
 Type=forking
 Restart=on-failure
-PIDFile={{ jira_installation_dir }}/work/catalina.pid
+PIDFile={{ jira_installation_dir }}/{{ jira_package_dir }}/work/catalina.pid
 User={{ jira_user }}
-ExecStart={{ jira_installation_dir }}/bin/start-jira.sh
-ExecStop={{ jira_installation_dir }}/bin/stop-jira.sh
+ExecStart={{ jira_installation_dir }}/{{ jira_package_dir }}/bin/start-jira.sh
+ExecStop={{ jira_installation_dir }}/{{ jira_package_dir }}/bin/stop-jira.sh
 LimitNOFILE={{ jira_service_max_nofiles }}
 
 [Install]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,5 @@
 ---
-jira_package: atlassian-jira-software-{{ jira_version }}.tar.gz
+jira_package_name: atlassian-jira-software
+jira_package_dir: "{{ jira_package_name }}-{{ jira_version }}-standalone"
+jira_package: "{{ jira_package_name }}-{{ jira_version }}.tar.gz"
 jira_installation_url: https://www.atlassian.com/software/jira/downloads/binary/{{ jira_package }}


### PR DESCRIPTION
### Description of the Change

Install Jira into its versioned install directory, in order to be able to have a clean
install directory which contains only the content of the tar-ball and to be able to have versions residing in parallel on the
same system.

### Benefits

Before tar-balls were installed into /opt/atlassian/jira.
When doing upgrades, the new tar-ball will be extracted to the same install directory, where files of the old version still are present. It may happen that a new version tar-ball adds a conflicting file to the installationdirectory, which causes that Jira is not starting anymore.
Solution is to have every version reside in its own install directory and have the systemd service unit pointing to the latest installed version.